### PR TITLE
Make the validation logic more permissive

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -19,9 +19,12 @@ module.exports = function plugins (config) {
 
     if (plugins.length > 0) {
       plugins.forEach(function (plugin) {
-        if (typeof plugin !== 'function') {
+        if (plugin.postcss) {
+          plugin = plugin.postcss
+        }
+        if (! (typeof plugin === 'object' && Array.isArray(plugin.plugins) || typeof plugin === 'function')) {
           throw new TypeError(
-            plugin + ' must be a function, did you require() it ?'
+            plugin + ' is not a valid PostCSS plugin, did you require() it ?'
           )
         }
       })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "standard",
-    "test": "nyc ava test/err/index.js test/rc/index.js test/pkg/index.js test/js/index.js",
+    "test": "nyc ava test/err/index.js test/rc/index.js test/pkg/index.js test/js/index.js test/js-array/index.js",
     "logs": "standard-changelog > CHANGELOG.md",
     "docs": "jsdoc2md index.js lib/plugins.js > INDEX.md",
     "clean": "rm -rf .nyc_output coverage jsdoc-api dmd",

--- a/test/js-array/expect/index.css
+++ b/test/js-array/expect/index.css
@@ -1,0 +1,19 @@
+.section {
+  color: goldenrod;
+}
+
+.test {
+  color: cyan;
+}
+
+.test__yellow {
+  color: yellow;
+}
+
+.test__navy {
+  color: navy;
+}
+
+.test__crimson {
+  color: crimson;
+}

--- a/test/js-array/expect/index.sss
+++ b/test/js-array/expect/index.sss
@@ -1,0 +1,19 @@
+.section {
+  color: goldenrod;
+}
+
+.test {
+  color: cyan;
+}
+
+.test__yellow {
+  color: yellow;
+}
+
+.test__navy {
+  color: navy;
+}
+
+.test__crimson {
+  color: crimson;
+}

--- a/test/js-array/fixtures/imports/section.css
+++ b/test/js-array/fixtures/imports/section.css
@@ -1,0 +1,3 @@
+.section {
+  color: goldenrod;
+}

--- a/test/js-array/fixtures/imports/section.sss
+++ b/test/js-array/fixtures/imports/section.sss
@@ -1,0 +1,2 @@
+.section
+  color: goldenrod

--- a/test/js-array/fixtures/index.css
+++ b/test/js-array/fixtures/index.css
@@ -1,0 +1,17 @@
+@import 'imports/section.css';
+
+.test {
+  color: cyan;
+
+  &__yellow {
+    color: yellow;
+  }
+
+  &__navy {
+    color: navy;
+  }
+
+  &__crimson {
+    color: crimson;
+  }
+}

--- a/test/js-array/fixtures/index.sss
+++ b/test/js-array/fixtures/index.sss
@@ -1,0 +1,13 @@
+@import 'imports/section.sss'
+
+.test
+  color: cyan
+
+  &__yellow
+    color: yellow
+
+  &__navy
+    color: navy
+
+  &__crimson
+    color: crimson

--- a/test/js-array/index.js
+++ b/test/js-array/index.js
@@ -1,0 +1,80 @@
+// ------------------------------------
+// #POSTCSS - LOAD PlUGINS - TEST
+// ------------------------------------
+
+'use strict'
+
+var test = require('ava')
+
+var join = require('path').join
+var read = require('fs').readFileSync
+
+var fixture = function (file) {
+  return read(join(__dirname, 'fixtures', file), 'utf8')
+}
+var expect = function (file) {
+  return read(join(__dirname, 'expect', file), 'utf8')
+}
+
+var postcss = require('postcss')
+var pluginsrc = require('../..')
+
+test('postcss.config.js - {Function} - Load Plugins', function (t) {
+  process.env.NODE_ENV = 'development'
+
+  return pluginsrc().then(function (plugins) {
+    t.is(plugins.length, 3)
+
+    t.is(plugins[0].postcssPlugin, 'postcss-import')
+    t.is(plugins[1].postcss, require('postcss-nested').postcss)
+    t.is(plugins[2], require('postcss-sprites'))
+  })
+})
+
+test('postcss.config.js - {Function} - Load Plugins', function (t) {
+  process.env.NODE_ENV = 'production'
+
+  return pluginsrc().then(function (plugins) {
+    t.is(plugins.length, 4)
+
+    t.is(plugins[0].postcssPlugin, 'postcss-import')
+    t.is(plugins[1].postcss, require('postcss-nested').postcss)
+    t.is(plugins[2], require('postcss-sprites'))
+    t.is(plugins[3].postcssPlugin, 'cssnano')
+  })
+})
+
+test('postcss.config.js - {Function} - Process CSS', function (t) {
+  process.env.NODE_ENV = 'development'
+
+  return pluginsrc().then(function (plugins) {
+    var options = {
+      from: 'fixtures/index.css',
+      to: 'expect/index.css'
+    }
+
+    return postcss(plugins)
+      .process(fixture('index.css'), options)
+      .then(function (result) {
+        t.is(expect('index.css'), result.css)
+      })
+  })
+})
+
+test('postcss.config.js - {Function} - Process SSS', function (t) {
+  process.env.NODE_ENV = 'development'
+
+  return pluginsrc().then(function (plugins) {
+    var options = {
+      parser: require('sugarss'),
+      from: 'fixtures/index.sss',
+      to: 'expect/index.sss'
+    }
+
+    return postcss(plugins)
+      .process(fixture('index.sss'), options)
+      .then(function (result) {
+        t.is(expect('index.sss'), result.css)
+      })
+  })
+})

--- a/test/js-array/postcss.config.js
+++ b/test/js-array/postcss.config.js
@@ -1,0 +1,13 @@
+module.exports = function (ctx) {
+  return {
+    plugins: [
+      require('postcss-import')(),
+      // simulate the case of require('doiuse') without actually requiring it
+      {
+        postcss: require('postcss-nested').postcss
+      },
+      require('postcss-sprites'),
+      ctx.env === 'development' ? false : require('cssnano')({}),
+    ].filter(Boolean)
+  }
+}


### PR DESCRIPTION
Check if the config would be accepted by [Processor.prototype.normalize](https://github.com/postcss/postcss/blob/master/lib/processor.es6#L98), which is what postcss actually calls before trying to use the plugins.

Fixes configs that return an array that have `doiuse` or `cssnext` instances with custom options. `require('doiuse')()` returns an object with a `postcss` key; `require('postcss-cssnext')()` returns an instance of `Processor` that satisfies `Array.isArray(require('postcss-cssnext')().plugins)`.

The caller could work around it by manually putting `.postcss` or `.plugins` in the array definition, but it'd be better to actually support the same arguments as the `postcss` function would support.

Tests are just a copy of the `src/js` folder changed to use an array instead of object config.